### PR TITLE
optional 'host' parameter to use any S3-compatible host

### DIFF
--- a/README
+++ b/README
@@ -130,6 +130,9 @@ METHODS
         If this library should retry upon errors. This option is
         recommended. This uses exponential backoff with retries after 1, 2,
         4, 8, 16, 32 seconds, as recommended by Amazon. Defaults to off.
+    host
+        The S3 host endpoint to use. Defaults to 's3.amazonaws.com'. This
+        allows you to connect to any S3-compatible host.
 
   buckets
     Returns undef on error, else hashref of results

--- a/lib/Net/Amazon/S3.pm
+++ b/lib/Net/Amazon/S3.pm
@@ -136,6 +136,7 @@ has 'aws_secret_access_key' => ( is => 'ro', isa => 'Str', required => 1 );
 has 'secure' => ( is => 'ro', isa => 'Bool', required => 0, default => 0 );
 has 'timeout' => ( is => 'ro', isa => 'Num',  required => 0, default => 30 );
 has 'retry'   => ( is => 'ro', isa => 'Bool', required => 0, default => 0 );
+has 'host'    => ( is => 'ro', isa => 'Str',  required => 0, default => 's3.amazonaws.com' );
 
 has 'libxml' => ( is => 'rw', isa => 'XML::LibXML',    required => 0 );
 has 'ua'     => ( is => 'rw', isa => 'LWP::UserAgent', required => 0 );
@@ -188,6 +189,11 @@ to 30.
 If this library should retry upon errors. This option is recommended.
 This uses exponential backoff with retries after 1, 2, 4, 8, 16, 32 seconds, 
 as recommended by Amazon. Defaults to off.
+
+=item host
+
+The S3 host endpoint to use. Defaults to 's3.amazonaws.com'. This allows
+you to connect to any S3-compatible host.
 
 =back
 

--- a/lib/Net/Amazon/S3/HTTPRequest.pm
+++ b/lib/Net/Amazon/S3/HTTPRequest.pm
@@ -37,9 +37,10 @@ sub http_request {
     $self->_add_auth_header( $http_headers, $method, $path )
         unless exists $headers->{Authorization};
     my $protocol = $self->s3->secure ? 'https' : 'http';
-    my $uri = "$protocol://s3.amazonaws.com/$path";
+    my $host = $self->s3->host;
+    my $uri = "$protocol://$host/$path";
     if ( $path =~ m{^([^/?]+)(.*)} && _is_dns_bucket($1) ) {
-        $uri = "$protocol://$1.s3.amazonaws.com$2";
+        $uri = "$protocol://$1.$host$2";
     }
 
     my $request
@@ -67,9 +68,10 @@ sub query_string_authentication_uri {
         = $self->_encode( $aws_secret_access_key, $canonical_string );
 
     my $protocol = $self->s3->secure ? 'https' : 'http';
-    my $uri = "$protocol://s3.amazonaws.com/$path";
+    my $host = $self->s3->host;
+    my $uri = "$protocol://$host/$path";
     if ( $path =~ m{^([^/?]+)(.*)} && _is_dns_bucket($1) ) {
-        $uri = "$protocol://$1.s3.amazonaws.com$2";
+        $uri = "$protocol://$1.$host$2";
     }
     $uri = URI->new($uri);
 


### PR DESCRIPTION
Allows `Net::Amazon::S3` to be used with any S3-compatible host by setting the `host` parameter when creating the `Net::Amazon::S3` object. This allows you to override the default of 's3.amazonaws.com'.

Example:

    my $s3 = Net::Amazon::S3->new({
    	aws_access_key_id     => $aws_access_key_id,
    	aws_secret_access_key => $aws_secret_access_key,
    	retry                 => 1,
    	host                  => 'my.s3.compatible.host.com',
    });

The `host` parameter already exists in the [`Amazon::S3`](http://search.cpan.org/~tima/Amazon-S3-0.45/lib/Amazon/S3.pm) module, so this feature is needed to make `Net::Amazon::S3` and [`Amazon::S3`](http://search.cpan.org/~tima/Amazon-S3-0.45/lib/Amazon/S3.pm) interchangeable.