### PR TITLE
allow easier subclassing of Net::Amazon::S3::Client

### DIFF
--- a/lib/Net/Amazon/S3/Client.pm
+++ b/lib/Net/Amazon/S3/Client.pm
@@ -12,6 +12,8 @@ has 's3' => ( is => 'ro', isa => 'Net::Amazon::S3', required => 1 );
 
 __PACKAGE__->meta->make_immutable;
 
+sub bucket_class { 'Net::Amazon::S3::Client::Bucket' }
+
 sub buckets {
     my $self = shift;
     my $s3   = $self->s3;
@@ -32,7 +34,7 @@ sub buckets {
         $xpc->findnodes('/s3:ListAllMyBucketsResult/s3:Buckets/s3:Bucket') )
     {
         push @buckets,
-            Net::Amazon::S3::Client::Bucket->new(
+            $self->bucket_class->new(
             {   client => $self,
                 name   => $xpc->findvalue( './s3:Name', $node ),
                 creation_date =>
@@ -49,7 +51,7 @@ sub buckets {
 sub create_bucket {
     my ( $self, %conf ) = @_;
 
-    my $bucket = Net::Amazon::S3::Client::Bucket->new(
+    my $bucket = $self->bucket_class->new(
         client => $self,
         name   => $conf{name},
     );
@@ -62,7 +64,7 @@ sub create_bucket {
 
 sub bucket {
     my ( $self, %conf ) = @_;
-    return Net::Amazon::S3::Client::Bucket->new(
+    return $self->bucket_class->new(
         client => $self,
         %conf,
     );
@@ -199,4 +201,10 @@ may change.
   # or use an existing bucket
   # returns a L<Net::Amazon::S3::Client::Bucket> object
   my $bucket = $client->bucket( name => $bucket_name );
+
+=head2 bucket_class
+
+  # returns string "Net::Amazon::S3::Client::Bucket"
+  # subclasses will want to override this.
+  my $bucket_class = $client->bucket_class
 

--- a/lib/Net/Amazon/S3/Client/Bucket.pm
+++ b/lib/Net/Amazon/S3/Client/Bucket.pm
@@ -66,6 +66,8 @@ sub location_constraint {
     return $lc;
 }
 
+sub object_class { 'Net::Amazon::S3::Client::Object' }
+
 sub list {
     my ( $self, $conf ) = @_;
     $conf ||= {};
@@ -102,7 +104,7 @@ sub list {
  #                $xpc->findvalue( ".//s3:DisplayName", $node ),
 
                 push @objects,
-                    Net::Amazon::S3::Client::Object->new(
+                    $self->object_class->new(
                     client => $self->client,
                     bucket => $self,
                     key    => $xpc->findvalue( './s3:Key', $node ),
@@ -132,7 +134,7 @@ sub list {
 
 sub object {
     my ( $self, %conf ) = @_;
-    return Net::Amazon::S3::Client::Object->new(
+    return $self->object_class->new(
         client => $self->client,
         bucket => $self,
         %conf,
@@ -226,4 +228,10 @@ This module represents buckets.
   # returns a L<Net::Amazon::S3::Client::Object>, which can then
   # be used to get or put
   my $object = $bucket->object( key => 'this is the key' );
+
+=head2 object_class
+
+  # returns string "Net::Amazon::S3::Client::Object"
+  # allowing subclasses to add behavior.
+  my $object_class = $bucket->object_class;
 


### PR DESCRIPTION
I'd like to subclass ::Object to provide a progress bar in my command line application, which is currently not very easy without hairy hacks (Hello, local *pkg::new...) so I changed the hard-coded class names to use methods. Could you apply this?