### PR TITLE
Add support for Content-Disposition header

### DIFF
--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -33,6 +33,11 @@ has 'content_type' => (
     required => 0,
     default  => 'binary/octet-stream'
 );
+has 'content_disposition' => (
+    is => 'ro',
+    isa => 'Str',
+    required => 0,
+);
 has 'content_encoding' => (
     is       => 'ro',
     isa      => 'Str',
@@ -121,6 +126,9 @@ sub put {
     }
     if ( $self->content_encoding ) {
         $conf->{'Content-Encoding'} = $self->content_encoding;
+    }
+    if ( $self->content_disposition ) { 
+        $conf->{'Content-Disposition'} = $self->content_disposition;
     }
 
     my $http_request = Net::Amazon::S3::Request::PutObject->new(


### PR DESCRIPTION
This simple patch for Net::Amazon::S3::Object.pm adds support for providing the Content-Disposition header to S3, which is very useful to provide a file name and wether a file should be download inline/as attachment via the public Amazon link.
