### PR TITLE
Allow content 'value' property to be ScalarRef

### DIFF
--- a/lib/Net/Amazon/S3/HTTPRequest.pm
+++ b/lib/Net/Amazon/S3/HTTPRequest.pm
@@ -21,7 +21,7 @@ has 'path'   => ( is => 'ro', isa => 'Str',             required => 1 );
 has 'headers' =>
     ( is => 'ro', isa => 'HashRef', required => 0, default => sub { {} } );
 has 'content' =>
-    ( is => 'ro', isa => 'Str|CodeRef', required => 0, default => '' );
+    ( is => 'ro', isa => 'Str|CodeRef|ScalarRef', required => 0, default => '' );
 has 'metadata' =>
     ( is => 'ro', isa => 'HashRef', required => 0, default => sub { {} } );
 

--- a/lib/Net/Amazon/S3/Request/PutObject.pm
+++ b/lib/Net/Amazon/S3/Request/PutObject.pm
@@ -7,7 +7,7 @@ extends 'Net::Amazon::S3::Request';
 
 has 'bucket'    => ( is => 'ro', isa => 'BucketName',      required => 1 );
 has 'key'       => ( is => 'ro', isa => 'Str',             required => 1 );
-has 'value'     => ( is => 'ro', isa => 'Str|CodeRef',     required => 1 );
+has 'value'     => ( is => 'ro', isa => 'Str|CodeRef|ScalarRef',     required => 1 );
 has 'acl_short' => ( is => 'ro', isa => 'Maybe[AclShort]', required => 0 );
 has 'headers' =>
     ( is => 'ro', isa => 'HashRef', required => 0, default => sub { {} } );

--- a/lib/Net/Amazon/S3/Request/PutPart.pm
+++ b/lib/Net/Amazon/S3/Request/PutPart.pm
@@ -5,7 +5,7 @@ extends 'Net::Amazon::S3::Request';
 
 has 'bucket'        => ( is => 'ro', isa => 'BucketName',      required => 1 );
 has 'key'           => ( is => 'ro', isa => 'Str',             required => 1 );
-has 'value'         => ( is => 'ro', isa => 'Str|CodeRef',     required => 0 );
+has 'value'         => ( is => 'ro', isa => 'Str|CodeRef|ScalarRef',     required => 0 );
 has 'upload_id'     => ( is => 'ro', isa => 'Str',             required => 1 );
 has 'part_number'   => ( is => 'ro', isa => 'Int',             required => 1 );
 has 'copy_source_bucket'    => ( is => 'ro', isa => 'Str',     required => 0 );


### PR DESCRIPTION
See issue #20 on pfig/net-amazon-s3. This adds support to Net::Amazon::S3::HTTPRequest (and classes that use it) for a ScalarRef content property. This makes using Net::Amazon::S3 with large amount of content more memory efficient, since it avoids memory buffers having to be allocated each time the scalar is copied from subroutine to subroutine.

N.B. Should higher-level API methods (such as Client::Object::put) wish to allow a client to pass in content via scalar ref, they should be modified accordingly to ensure they treat any scalar ref value properly (e.g. calculating the md5 correctly) before calling the underlying class but this can be addressed independently.