### PR TITLE
Use CredentialsProviders à la the Java API (NOT YET DOCUMENTED)

### DIFF
--- a/lib/Net/Amazon/Auth/CredentialsProvider.pm
+++ b/lib/Net/Amazon/Auth/CredentialsProvider.pm
@@ -1,0 +1,9 @@
+package Net::Amazon::Auth::CredentialsProvider;
+
+use Moose::Role 0.85;
+
+requires 'get_credentials';
+
+sub refresh { }
+
+1;

--- a/lib/Net/Amazon/Auth/CredentialsProviderChain.pm
+++ b/lib/Net/Amazon/Auth/CredentialsProviderChain.pm
@@ -1,0 +1,41 @@
+package Net::Amazon::Auth::CredentialsProviderChain;
+
+use Moose 0.85;
+use MooseX::StrictConstructor 0.16;
+use Net::Amazon::Auth::EnvironmentVariableCredentialsProvider;
+use Net::Amazon::Auth::InstanceProfileCredentialsProvider;
+
+with 'Net::Amazon::Auth::CredentialsProvider';
+
+has 'providers' => ( is => 'ro', isa => 'ArrayRef[Net::Amazon::Auth::CredentialsProvider]', required => 1 );
+
+sub refresh {
+    my $self = shift;
+
+    map { $_->refresh } @{$self->providers};
+}
+
+sub get_credentials {
+    my $self = shift;
+
+    foreach my $provider (@{$self->providers}) {
+        my $res = $provider->get_credentials;
+        if (defined $res->{access_key_id}) {
+            return $res;
+        }
+    }
+
+    return {};
+}
+
+sub default_chain {
+    my $class = shift;
+    return $class->new(providers => [
+            Net::Amazon::Auth::EnvironmentVariableCredentialsProvider->new,
+            Net::Amazon::Auth::InstanceProfileCredentialsProvider->new
+        ]);
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/Net/Amazon/Auth/EnvironmentVariableCredentialsProvider.pm
+++ b/lib/Net/Amazon/Auth/EnvironmentVariableCredentialsProvider.pm
@@ -1,0 +1,26 @@
+package Net::Amazon::Auth::EnvironmentVariableCredentialsProvider;
+
+use Moose 0.85;
+use MooseX::StrictConstructor 0.16;
+
+extends 'Net::Amazon::Auth::FixedCredentialsProvider';
+
+around BUILDARGS => sub {
+    my $orig = shift;
+    my $class = shift;
+
+    my %args = (
+        access_key_id => $ENV{AWS_ACCESS_KEY_ID},
+        secret_access_key => $ENV{AWS_SECRET_ACCESS_KEY}
+    );
+
+    if (exists $ENV{AWS_SESSION_TOKEN}) {
+        $args{session_token} = $ENV{AWS_SESSION_TOKEN};
+    }
+
+    return $class->$orig(\%args);
+};
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/Net/Amazon/Auth/FixedCredentialsProvider.pm
+++ b/lib/Net/Amazon/Auth/FixedCredentialsProvider.pm
@@ -1,0 +1,23 @@
+package Net::Amazon::Auth::FixedCredentialsProvider;
+
+use Moose 0.85;
+use MooseX::StrictConstructor 0.16;
+
+with 'Net::Amazon::Auth::CredentialsProvider';
+
+has 'access_key_id'     => ( is => 'ro', isa => 'Maybe[Str]', required => 1 );
+has 'secret_access_key' => ( is => 'ro', isa => 'Maybe[Str]', required => 1 );
+has 'session_token' => ( is => 'ro', isa => 'Maybe[Str]', required => 0 );
+
+sub get_credentials {
+    my $self = shift;
+    return {
+        access_key_id => $self->access_key_id,
+        secret_access_key => $self->secret_access_key,
+        session_token => $self->session_token
+    };
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/Net/Amazon/Auth/InstanceProfileCredentialsProvider.pm
+++ b/lib/Net/Amazon/Auth/InstanceProfileCredentialsProvider.pm
@@ -1,0 +1,57 @@
+package Net::Amazon::Auth::InstanceProfileCredentialsProvider;
+
+use Moose 0.85;
+use MooseX::StrictConstructor 0.16;
+use HTTP::Date;
+use JSON;
+
+with 'Net::Amazon::Auth::CredentialsProvider';
+
+has '_ua' => ( is => 'rw', isa => 'LWP::UserAgent', required => 0 );
+has '_access_key_id'     => ( is => 'rw', isa => 'Str', required => 0 );
+has '_secret_access_key' => ( is => 'rw', isa => 'Str', required => 0 );
+has '_session_token' => ( is => 'rw', isa => 'Str', required => 0 );
+has '_expiration_date' => ( is => 'rw', isa => 'Int', required => 0, default => 0 );
+
+sub BUILD {
+    my $self = shift;
+    my $ua = LWP::UserAgent->new;
+    $ua->timeout(10);
+    $self->_ua($ua);
+}
+
+sub refresh {
+    my $self = shift;
+
+    my $role_name_response =
+        $self->_ua->get("http://169.254.169.254/latest/meta-data/iam/security-credentials/");
+    if ($role_name_response->code == 200) {
+        my $credentials_response = $self->_ua->get("http://169.254.169.254/latest/meta-data/iam/security-credentials/" . $role_name_response->content);
+
+        if ($credentials_response->code == 200) {
+            my $credentials = decode_json($credentials_response->content);
+            $self->_expiration_date(str2time($credentials->{Expiration}));
+            $self->_access_key_id($credentials->{AccessKeyId});
+            $self->_secret_access_key($credentials->{SecretAccessKey});
+            $self->_session_token($credentials->{Token});
+        }
+    }
+}
+
+sub get_credentials {
+    my $self = shift;
+
+    if (time() - $self->_expiration_date > -5 * 60) { #Credentials available 5 minutes before expiry
+        $self->refresh;
+    }
+
+    return {
+        access_key_id => $self->_access_key_id,
+        secret_access_key => $self->_secret_access_key,
+        session_token => $self->_session_token
+    };
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/Net/Amazon/S3/HTTPRequest.pm
+++ b/lib/Net/Amazon/S3/HTTPRequest.pm
@@ -63,8 +63,9 @@ sub query_string_authentication_uri {
     my $path    = $self->path;
     my $headers = $self->headers;
 
-    my $aws_access_key_id     = $self->s3->aws_access_key_id;
-    my $aws_secret_access_key = $self->s3->aws_secret_access_key;
+    my $creds = $self->s3->credentials_provider->get_credentials;
+    my $aws_access_key_id     = $creds->{access_key_id};
+    my $aws_secret_access_key = $creds->{secret_access_key};
     my $canonical_string
         = $self->_canonical_string( $method, $path, $headers, $expires );
     my $encoded_canonical
@@ -86,9 +87,10 @@ sub query_string_authentication_uri {
 
 sub _add_auth_header {
     my ( $self, $headers, $method, $path ) = @_;
-    my $aws_access_key_id     = $self->s3->aws_access_key_id;
-    my $aws_secret_access_key = $self->s3->aws_secret_access_key;
-    my $aws_session_token     = $self->s3->aws_session_token;
+    my $creds = $self->s3->credentials_provider->get_credentials;
+    my $aws_access_key_id     = $creds->{access_key_id};
+    my $aws_secret_access_key = $creds->{secret_access_key};
+    my $aws_session_token     = $creds->{session_token};
 
     if ( not $headers->header('Date') ) {
         $headers->header( Date => time2str(time) );


### PR DESCRIPTION
This PR changes `Net::Amazon::S3` to use `CredentialsProvider`s instead of only fixed credentials to access S3 (while maintaining backwards compatibility). The added `CredentialsProvider` implementations match the official Java SDK (minus the one using JVM properties for obvious reasons), and the default for `credentials_provider` matches as well.

In practice, what this means is that if you create a new `Net::Amazon::S3` instance with no credentials, it will check the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables (also the less-used `AWS_SESSION_TOKEN`), and if those are not set it will look for credentials provided by instance metadata on EC2 instances with attached IAM roles. Previously-working scripts should still work: If credentials are provided to the constructor instead of a `CredentialsProvider`, then we create a `FixedCredentialsProvider` under the hood using the supplied creds.

Note that this is my first time working with Moose and I have not yet learned how to write POD documentation, so this is as-yet undocumented and may contain obvious mistakes. I'm happy to take the time to learn to document this, but before I do so I'd like to know if this change is conceivably welcome or not.