### PR TITLE
Address an error message about enums

### DIFF
--- a/lib/Net/Amazon/S3/Client/Object.pm
+++ b/lib/Net/Amazon/S3/Client/Object.pm
@@ -13,10 +13,10 @@ use IO::File 1.14;
 # ABSTRACT: An easy-to-use Amazon S3 client object
 
 enum 'AclShort' =>
-    qw(private public-read public-read-write authenticated-read);
+    [qw(private public-read public-read-write authenticated-read)];
 
 enum 'StorageClass' =>
-    qw(standard reduced_redundancy);
+    [qw(standard reduced_redundancy)];
 
 has 'client' =>
     ( is => 'ro', isa => 'Net::Amazon::S3::Client', required => 1 );


### PR DESCRIPTION
"Passing a list of values to enum is deprecated. Enum values should be wrapped in an arrayref."