### PR TITLE
replace defined-or operator to improve compatibility with older perl (issue #30)

### DIFF
--- a/lib/Net/Amazon/S3/Request/PutPart.pm
+++ b/lib/Net/Amazon/S3/Request/PutPart.pm
@@ -38,7 +38,7 @@ sub http_request {
                    '&uploadId=' .
                    $self->upload_id,
         headers => $headers,
-        content => $self->value // '',
+        content => defined($self->value) ? $self->value : '',
     )->http_request;
 }
 


### PR DESCRIPTION
replace defined-or operator with pre-perl 5.10 equivalent to make us
compatible with older Perls