### PR TITLE
Fixed a bug in Etags validation

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = Net-Amazon-S3
 author  = Pedro Figueiredo <me@pedrofigueiredo.org>
 license = Perl_5
 copyright_holder = Amazon Digital Services, Leon Brocard, Brad Fitzpatrick, Pedro Figueiredo
-version = 0.59
+version = 0.61
 
 [@Filter]
 -bundle = @Basic

--- a/lib/Net/Amazon/S3/Client.pm
+++ b/lib/Net/Amazon/S3/Client.pm
@@ -6,7 +6,7 @@ use Moose::Util::TypeConstraints;
 
 # ABSTRACT: An easy-to-use Amazon S3 client
 
-type 'Etag' => where { $_ =~ /^[a-z0-9]{32}$/ };
+type 'Etag' => where { $_ =~ /^[a-z0-9]{32}(?:-\d+)?$/ };
 
 type 'OwnerId' => where { $_ =~ /^[a-z0-9]{64}$/ };
 


### PR DESCRIPTION
This regex needs to be expanded to account for additional types of Etags coming back from Amazon S3, otherwise validation fails.